### PR TITLE
Support arbitrary internal test clouds by passing through https:// URLs

### DIFF
--- a/zpa/provider.go
+++ b/zpa/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -45,8 +46,14 @@ func ZPAProvider() *schema.Provider {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Cloud to use PRODUCTION, ZPATWO, BETA, GOV, GOVUS, PREVIEW, DEV, QA, QA2",
-				ValidateFunc: validation.StringInSlice([]string{"PRODUCTION", "ZPATWO", "BETA", "GOV", "GOVUS", "PREVIEW", "DEV", "QA", "QA2"}, true),
 				DefaultFunc:  schema.EnvDefaultFunc("ZPA_CLOUD", nil),
+				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if strings.HasPrefix(v, "https://") {
+						return
+					}
+					return validation.StringInSlice([]string{"PRODUCTION", "ZPATWO", "BETA", "GOV", "GOVUS", "PREVIEW", "DEV", "QA", "QA2"}, true)(val, key)
+				},
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Rebased, re-tested, re-submitted- it's annoying to have to pass around internal builds for this. [SDK support](https://github.com/zscaler/zscaler-sdk-go/pull/15) got merged a couple years ago now.