### PR TITLE
Updating go code to support CHROME_ENTERPRISE object_type

### DIFF
--- a/docs/resources/zpa_policy_access_rule.md
+++ b/docs/resources/zpa_policy_access_rule.md
@@ -53,6 +53,20 @@ resource "zpa_policy_access_rule" "this" {
       rhs = data.zpa_scim_groups.engineering.id
     }
   }
+  conditions {
+    operator = "OR"
+    operands {
+      object_type = "CHROME_ENTERPRISE"
+      entry_values {
+        lhs = "managed"
+        rhs = "true"
+      }
+      entry_values {
+        lhs = "managed"
+        rhs = "false"
+      }
+    }
+  }
 }
 ```
 
@@ -139,3 +153,4 @@ terraform import zpa_policy_access_rule.example <policy_access_rule_id>
 | [TRUSTED_NETWORK](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/data-sources/zpa_trusted_network) | ``network_id``  | ``"true"`` |
 | [COUNTRY_CODE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/data-sources/zpa_access_policy_platforms) | [2 Letter ISO3166 Alpha2](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)  | ``"true"`` / ``"false"`` |
 | [RISK_FACTOR_TYPE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/resources/zpa_policy_access_rule) | ``ZIA``  | ``"UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"`` |
+| [CHROME_ENTERPRISE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/resources/zpa_policy_access_rule) | ``managed``  | ``"true"`` / ``"false"`` |

--- a/docs/resources/zpa_policy_access_rule_v2.md
+++ b/docs/resources/zpa_policy_access_rule_v2.md
@@ -152,6 +152,20 @@ resource "zpa_policy_access_rule_v2" "this" {
       }
     }
   }
+  conditions {
+    operator = "OR"
+    operands {
+      object_type = "CHROME_ENTERPRISE"
+      entry_values {
+        lhs = "managed"
+        rhs = "true"
+      }
+      entry_values {
+        lhs = "managed"
+        rhs = "false"
+      }
+    }
+  }
 ```
 
 ## Schema
@@ -224,6 +238,14 @@ resource "zpa_policy_access_rule_v2" "this" {
             - `lhs` - (String) -  2 Letter Country in ``ISO 3166 Alpha2 Code`` [Lear More](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
             - `rhs` - (String) - Supported values: `"true"` or `"false"`
 
+- `conditions` (Block Set) - This is for providing the set of conditions for the policy
+    - `operator` (String) - Supported values are: `AND` or `OR`
+    - `operands` (Block Set) - This signifies the various policy criteria. Supported Values: `object_type`, `entry_values`
+        - `object_type` (String) This is for specifying the policy criteria. Supported values: `CHROME_ENTERPRISE`
+        - `entry_values` (Block Set)
+            - `lhs` - (String) -  Must be set to `managed`
+            - `rhs` - (String) - Supported values: `"true"` or `"false"`
+
 ## Import
 
 Zscaler offers a dedicated tool called Zscaler-Terraformer to allow the automated import of ZPA configurations into Terraform-compliant HashiCorp Configuration Language.
@@ -256,3 +278,4 @@ terraform import zpa_policy_access_rule_v2.example <rule_id>
 | [TRUSTED_NETWORK](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/data-sources/zpa_trusted_network) | ``network_id``  | ``"true"`` |
 | [COUNTRY_CODE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/data-sources/zpa_access_policy_platforms) | [2 Letter ISO3166 Alpha2](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)  | ``"true"`` / ``"false"`` |
 | [RISK_FACTOR_TYPE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/resources/zpa_policy_access_rule) | ``ZIA``  | ``"UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"`` |
+| [CHROME_ENTERPRISE](https://registry.terraform.io/providers/zscaler/zpa/latest/docs/resources/zpa_policy_access_rule) | ``managed``  | ``"true"`` / ``"false"`` |

--- a/zpa/common.go
+++ b/zpa/common.go
@@ -210,6 +210,20 @@ func validateOperand(operand policysetcontroller.Operands, zClient *Client, micr
 			return rhsWarn(operand.ObjectType, "\"UNKNOWN\", \"LOW\", \"MEDIUM\", \"HIGH\", \"CRITICAL\"", operand.RHS, nil)
 		}
 		return nil
+	case "CHROME_ENTERPRISE":
+		if operand.LHS == "" {
+			return lhsWarn(operand.ObjectType, "managed", operand.LHS, nil)
+		}
+		if operand.LHS != "managed" {
+			return lhsWarn(operand.ObjectType, "managed", operand.LHS, nil)
+		}
+		if operand.RHS == "" {
+			return rhsWarn(operand.ObjectType, "true/false", operand.RHS, nil)
+		}
+		if operand.RHS != "true" && operand.RHS != "false" {
+			return rhsWarn(operand.ObjectType, "true/false", operand.RHS, nil)
+		}
+		return nil
 	default:
 		return fmt.Errorf("[WARN] invalid operand object type %s", operand.ObjectType)
 	}
@@ -1210,6 +1224,23 @@ func ValidatePolicyRuleConditions(d *schema.ResourceData) error {
 					}
 					if rhs == "" {
 						return fmt.Errorf("RHS must be a valid scim group ID and cannot be empty for SCIM_GROUP object_type")
+					}
+				}
+			case "CHROME_ENTERPRISE":
+				entryValuesSet, ok := operandMap["entry_values"].(*schema.Set)
+				if !ok || entryValuesSet.Len() == 0 {
+					return fmt.Errorf("entry_values must be provided for CHROME_ENTERPRISE object_type")
+				}
+				for _, ev := range entryValuesSet.List() {
+					evMap := ev.(map[string]interface{})
+					lhs, lhsOk := evMap["lhs"].(string)
+					rhs, rhsOk := evMap["rhs"].(string)
+
+					if !lhsOk || lhs == "" {
+						return fmt.Errorf("LHS must be a valid Chrome Enterprise ID and cannot be empty for CHROME_ENTERPRISE object_type")
+					}
+					if !rhsOk || rhs != "true" {
+						return fmt.Errorf("rhs value must be 'true' for CHROME_ENTERPRISE object_type")
 					}
 				}
 			}

--- a/zpa/resource_zpa_policy_access_rule.go
+++ b/zpa/resource_zpa_policy_access_rule.go
@@ -82,6 +82,7 @@ func resourcePolicyAccessRule() *schema.Resource {
 					"COUNTRY_CODE",
 					"PLATFORM",
 					"RISK_FACTOR_TYPE",
+					"CHROME_ENTERPRISE",
 				}),
 			},
 		),

--- a/zpa/resource_zpa_policy_access_rule_test.go
+++ b/zpa/resource_zpa_policy_access_rule_test.go
@@ -53,7 +53,7 @@ func TestAccResourcePolicyAccessRule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceTypeAndName, "action", "ALLOW"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "operator", "AND"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "app_connector_groups.#", "1"),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "3"),
 				),
 			},
 			// Import test
@@ -214,6 +214,19 @@ resource "%s" "%s" {
 		  object_type = "RISK_FACTOR_TYPE"
 		  lhs         = "ZIA"
 		  rhs         = "CRITICAL"
+		}
+	}
+	conditions {
+		operator = "OR"
+		operands {
+			object_type = "CHROME_ENTERPRISE"
+			lhs = "managed"
+			rhs = "true"
+		}
+		operands {
+			object_type = "CHROME_ENTERPRISE"
+			lhs = "managed"
+			rhs = "false"
 		}
 	}
 	depends_on = [ %s, %s ]

--- a/zpa/resource_zpa_policy_access_rule_v2.go
+++ b/zpa/resource_zpa_policy_access_rule_v2.go
@@ -120,6 +120,7 @@ func resourcePolicyAccessRuleV2() *schema.Resource {
 											"COUNTRY_CODE",
 											"PLATFORM",
 											"RISK_FACTOR_TYPE",
+											"CHROME_ENTERPRISE",
 										}, false),
 									},
 									"entry_values": {

--- a/zpa/resource_zpa_policy_access_rule_v2_test.go
+++ b/zpa/resource_zpa_policy_access_rule_v2_test.go
@@ -39,7 +39,7 @@ func TestAccResourcePolicyAccessRuleV2_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceTypeAndName, "action", "ALLOW"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "operator", "AND"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "app_connector_groups.#", "1"),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "5"),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "6"),
 				),
 			},
 
@@ -53,7 +53,7 @@ func TestAccResourcePolicyAccessRuleV2_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceTypeAndName, "action", "ALLOW"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "operator", "AND"),
 					resource.TestCheckResourceAttr(resourceTypeAndName, "app_connector_groups.#", "1"),
-					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "5"),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "conditions.#", "6"),
 				),
 			},
 			// Import test
@@ -242,6 +242,20 @@ resource "%s" "%s" {
 			lhs = "ZIA"
 			rhs = "MEDIUM"
 		  }
+		}
+	}
+	conditions {
+		operator = "OR"
+		operands {
+			object_type = "CHROME_ENTERPRISE"
+			entry_values {
+				lhs = "managed"
+				rhs = "true"
+			}
+			entry_values {
+				lhs = "managed"
+				rhs = "false"
+			}
 		}
 	}
 	depends_on = [ %s, %s ]


### PR DESCRIPTION
For ZPA access policies for browser access, this Terraform provider does not current support the conditional check for Chrome Enterprise Browser. Creating this PR in the hope of supporting this feature. I've tested locally and it appears functional.

## Description

This is a supported feature in the ZPA console. The Terraform provider should be updated to reflect this supported feature. Without this change, the ZPA terraform provider will remove this condition from a given access policy that has the condition enabled.

## Has your change been tested?

I tested locally by hosting the provider in the Terraform provider repository and replacing the source in my `providers.tf` file. Before: `source = "zscaler/zpa"; After: `source = "publicfacingusername/zpa"`. Also ran `make test`. Output below:
```
echo $(go list ./... |grep -v 'vendor') | \
		xargs -t -n4 go test -test.v  -timeout=30s -parallel=10
?   	github.com/zscaler/terraform-provider-zpa/v3	[no test files]
?   	github.com/zscaler/terraform-provider-zpa/v3/zpa/common	[no test files]
?   	github.com/zscaler/terraform-provider-zpa/v3/zpa/common/resourcetype	[no test files]
2024/12/10 05:39:25 [WARN]  testSdkClient is not initialized. Initializing now...
[INFO] initialized ZPA client
=== RUN   TestAccDataSourceAccessPolicyClientTypes_Basic
=== PAUSE TestAccDataSourceAccessPolicyClientTypes_Basic
=== RUN   TestAccDataSourceAccessPolicyPlatforms_Basic
=== PAUSE TestAccDataSourceAccessPolicyPlatforms_Basic
=== RUN   TestAccDataSourceAppConnectorAssistantSchedule_Basic
    data_source_zpa_app_connector_assistant_schedule_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceAppConnectorAssistantSchedule_Basic (0.00s)
=== RUN   TestAccDataSourceAppConnectorGroup_Basic
    data_source_zpa_app_connector_group_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceAppConnectorGroup_Basic (0.00s)
=== RUN   TestAccDataSourceApplicationServer_Basic
    data_source_zpa_app_server_controller_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceApplicationServer_Basic (0.00s)
=== RUN   TestAccDataSourceApplicationSegmentBrowserAccess_Basic
    data_source_zpa_application_segment_browser_access_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceApplicationSegmentBrowserAccess_Basic (0.00s)
=== RUN   TestAccDataSourceApplicationSegmentInspection_Basic
    data_source_zpa_application_segment_inspection_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceApplicationSegmentInspection_Basic (0.00s)
=== RUN   TestAccDataSourceApplicationSegmentPRA_Basic
    data_source_zpa_application_segment_pra_test.go:22: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceApplicationSegmentPRA_Basic (0.00s)
=== RUN   TestAccDataSourceApplicationSegment_Basic
    data_source_zpa_application_segment_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceApplicationSegment_Basic (0.00s)
=== RUN   TestAccDataSourceBaCertificate_Basic
    data_source_zpa_ba_certificate_test.go:22: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceBaCertificate_Basic (0.05s)
=== RUN   TestAccDataSourceCBIBanners_Basic
    data_source_zpa_cloud_browser_isolation_banner_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceCBIBanners_Basic (0.00s)
=== RUN   TestAccDataSourceBaCertificates_Basic
    data_source_zpa_cloud_browser_isolation_certificate_test.go:18: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceBaCertificates_Basic (0.75s)
=== RUN   TestAccDataSourceCBIRegions_Basic
    data_source_zpa_cloud_browser_isolation_region_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceCBIRegions_Basic (0.00s)
=== RUN   TestAccDataSourceCBIZPAProfiles_Basic
    data_source_zpa_cloud_browser_isolation_zpaprofiles_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceCBIZPAProfiles_Basic (0.00s)
=== RUN   TestAccDataSourceCustomerVersionProfile_Basic
    data_source_zpa_customer_version_profile_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceCustomerVersionProfile_Basic (0.00s)
=== RUN   TestAccDataSourceEnrollmentCert_Basic
    data_source_zpa_enrollement_cert_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceEnrollmentCert_Basic (0.00s)
=== RUN   TestAccDataSourceIdpController_Basic
    data_source_zpa_idp_controller_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceIdpController_Basic (0.00s)
=== RUN   TestAccDataSourceInspectionAllPredefinedControls_Basic
    data_source_zpa_inspection_all_predefined_controls_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceInspectionAllPredefinedControls_Basic (0.00s)
=== RUN   TestAccDataSourceInspectionCustomControls_Basic
    data_source_zpa_inspection_custom_controls_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceInspectionCustomControls_Basic (0.00s)
=== RUN   TestAccDataSourceInspectionPredefinedControls_Basic
    data_source_zpa_inspection_predefined_controls_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceInspectionPredefinedControls_Basic (0.00s)
=== RUN   TestAccDataSourceIsolationRule_Basic
    data_source_zpa_isolation_profiles_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceIsolationRule_Basic (0.00s)
=== RUN   TestAccDataSourceLSSClientTypes_Basic
=== PAUSE TestAccDataSourceLSSClientTypes_Basic
=== RUN   TestAccDataSourceLSSConfigController_Basic
    data_source_zpa_lss_config_controller_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceLSSConfigController_Basic (0.00s)
=== RUN   TestAccDataSourceLSSLogTypeFormats_Basic
    data_source_zpa_lss_config_log_types_formats_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceLSSLogTypeFormats_Basic (0.00s)
=== RUN   TestAccDataSourceLSSStatusCodes_Basic
=== PAUSE TestAccDataSourceLSSStatusCodes_Basic
=== RUN   TestAccDataSourceMachineGroup_Basic
    data_source_zpa_machine_group_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceMachineGroup_Basic (0.00s)
=== RUN   TestAccDataSourcePolicyType_Basic
    data_source_zpa_policy_type_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePolicyType_Basic (0.00s)
=== RUN   TestAccDataSourcePostureProfile_Basic
    data_source_zpa_posture_profile_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePostureProfile_Basic (0.00s)
=== RUN   TestAccDataSourcePRAPrivilegedApproval_Basic
    data_source_zpa_pra_approval_test.go:14: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePRAPrivilegedApproval_Basic (0.00s)
=== RUN   TestAccDataSourcePRAConsoleController_Basic
    data_source_zpa_pra_console_test.go:20: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePRAConsoleController_Basic (0.00s)
=== RUN   TestAccDataSourcePRACredentialController_Basic
    data_source_zpa_pra_credential_controller_test.go:17: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePRACredentialController_Basic (0.00s)
=== RUN   TestAccDataSourcePRAPortalController_Basic
    data_source_zpa_pra_portal_controller_test.go:17: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourcePRAPortalController_Basic (0.00s)
=== RUN   TestAccDataSourceProvisioningKeyAppConnectorGroup_Basic
    data_source_zpa_provisioning_key_test.go:19: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceProvisioningKeyAppConnectorGroup_Basic (0.00s)
=== RUN   TestAccDataSourceSamlAttribute_Basic
    data_source_zpa_saml_attribute_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceSamlAttribute_Basic (0.00s)
=== RUN   TestAccDataSourceScimAttributeHeader_Basic
    data_source_zpa_scim_attribute_header_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceScimAttributeHeader_Basic (0.00s)
=== RUN   TestAccDataSourceScimGroup_Basic
    data_source_zpa_scim_group_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceScimGroup_Basic (0.00s)
=== RUN   TestAccDataSourceSegmentGroup_Basic
    data_source_zpa_segment_group_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceSegmentGroup_Basic (0.00s)
=== RUN   TestAccDataSourceServerGroup_Basic
    data_source_zpa_server_group_test.go:19: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceServerGroup_Basic (0.00s)
=== RUN   TestAccDataSourceServiceEdgeAssistantSchedule_Basic
    data_source_zpa_service_edge_assistant_schedule_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceServiceEdgeAssistantSchedule_Basic (0.00s)
=== RUN   TestAccDataSourceServiceEdgeGroup_Basic
    data_source_zpa_service_edge_group_test.go:16: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceServiceEdgeGroup_Basic (0.00s)
=== RUN   TestAccDataSourceTrustedNetwork_Basic
    data_source_zpa_trusted_network_test.go:18: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceTrustedNetwork_Basic (0.00s)
=== RUN   TestRunForcedSweeper
    provider_sweeper_test.go:72: ENV vars "ZPA_ACC_TEST_FORCE_SWEEPERS" and "TF_ACC" must not be blank to force running of the sweepers
--- SKIP: TestRunForcedSweeper (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccAppConnectorAssistantSchedule_Basic
    resource_zpa_app_connector_assistant_schedule_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccAppConnectorAssistantSchedule_Basic (0.00s)
=== RUN   TestAccResourceAppConnectorGroup_Basic
    resource_zpa_app_connector_group_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceAppConnectorGroup_Basic (0.00s)
=== RUN   TestAccResourceApplicationServer_Basic
    resource_zpa_app_server_controller_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceApplicationServer_Basic (0.00s)
=== RUN   TestAccResourceApplicationSegmentBrowserAccess_Basic
    resource_zpa_application_segment_browser_access_test.go:27: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceApplicationSegmentBrowserAccess_Basic (0.00s)
=== RUN   TestAccResourceApplicationSegmentInspection_Basic
    resource_zpa_application_segment_inspection_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceApplicationSegmentInspection_Basic (0.00s)
=== RUN   TestAccResourceApplicationSegmentPRA_Basic
    resource_zpa_application_segment_pra_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceApplicationSegmentPRA_Basic (0.00s)
=== RUN   TestAccResourceApplicationSegment_Basic
    resource_zpa_application_segment_test.go:27: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceApplicationSegment_Basic (0.00s)
=== RUN   TestAccResourceBaCertificate_Basic
    resource_zpa_ba_certificate_test.go:31: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceBaCertificate_Basic (0.03s)
=== RUN   TestAccResourceCBIBanners_Basic
    resource_zpa_cloud_browser_isolation_banner_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceCBIBanners_Basic (0.00s)
=== RUN   TestAccResourceCBICertificate_Basic
    resource_zpa_cloud_browser_isolation_certificate_test.go:34: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceCBICertificate_Basic (0.44s)
=== RUN   TestAccResourceInspectionCustomControls_Basic
    resource_zpa_inspection_custom_controls_test.go:19: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceInspectionCustomControls_Basic (0.00s)
=== RUN   TestAccResourceLSSConfigController_Basic
    resource_zpa_lss_config_controller_test.go:26: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceLSSConfigController_Basic (0.00s)
=== RUN   TestAccResourcePolicyForwardingRule_Basic
    resource_zpa_policy_access_forwarding_rule_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyForwardingRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyForwardingRuleV2_Basic
    resource_zpa_policy_access_forwarding_rule_v2_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyForwardingRuleV2_Basic (0.00s)
=== RUN   TestAccResourcePolicyInspectionRule_Basic
    resource_zpa_policy_access_inspection_rule_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyInspectionRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyInspectionRuleV2_Basic
    resource_zpa_policy_access_inspection_rule_v2_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyInspectionRuleV2_Basic (0.00s)
=== RUN   TestAccResourcePolicyIsolationRule_Basic
    resource_zpa_policy_access_isolation_rule_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyIsolationRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyIsolationRuleV2_Basic
    resource_zpa_policy_access_isolation_rule_v2_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyIsolationRuleV2_Basic (0.00s)
=== RUN   TestAccResourcePolicyRedictionRule_Basic
    resource_zpa_policy_access_redirection_rule_test.go:25: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyRedictionRule_Basic (0.00s)
=== RUN   TestAccZPAResourcePolicyAccessRuleReorder_Basic
    resource_zpa_policy_access_rule_reorder_test.go:17: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccZPAResourcePolicyAccessRuleReorder_Basic (0.00s)
=== RUN   TestAccResourcePolicyAccessRule_Basic
    resource_zpa_policy_access_rule_test.go:28: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyAccessRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyAccessRuleV2_Basic
    resource_zpa_policy_access_rule_v2_test.go:28: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyAccessRuleV2_Basic (0.00s)
=== RUN   TestAccResourcePolicyTimeoutRule_Basic
    resource_zpa_policy_access_timeout_rule_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyTimeoutRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyTimeoutRuleV2_Basic
    resource_zpa_policy_access_timeout_rule_v2_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyTimeoutRuleV2_Basic (0.00s)
=== RUN   TestAccResourcePolicyCapabilitiesAccessRule_Basic
    resource_zpa_policy_capabilities_access_rule_test.go:20: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyCapabilitiesAccessRule_Basic (0.00s)
=== RUN   TestAccResourcePolicyCredentialAccessRule_Basic
    resource_zpa_policy_credential_access_rule_test.go:25: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePolicyCredentialAccessRule_Basic (0.00s)
=== RUN   TestAccResourcePRAPrivilegedApprovalController_Basic
    resource_zpa_pra_approval_test.go:20: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePRAPrivilegedApprovalController_Basic (0.00s)
=== RUN   TestAccResourcePRAConsoleController_Basic
    resource_zpa_pra_console_controller_test.go:27: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePRAConsoleController_Basic (0.00s)
=== RUN   TestAccResourcePRACredentialController_Basic
    resource_zpa_pra_credential_controller_test.go:25: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePRACredentialController_Basic (0.00s)
=== RUN   TestAccResourcePRAPortalController_Basic
    resource_zpa_pra_portal_controller_test.go:25: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourcePRAPortalController_Basic (0.00s)
=== RUN   TestAccResourceProvisioningKeyConnector_Basic
    resource_zpa_provisioning_key_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceProvisioningKeyConnector_Basic (0.00s)
=== RUN   TestAccResourceSegmentGroup_Basic
    resource_zpa_segment_group_test.go:23: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceSegmentGroup_Basic (0.00s)
=== RUN   TestAccResourceServerGroup_Basic
    resource_zpa_server_group_test.go:22: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceServerGroup_Basic (0.00s)
=== RUN   TestAccServiceEdgeAssistantSchedule_Basic
    resource_zpa_service_edge_assistant_schedule_test.go:21: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccServiceEdgeAssistantSchedule_Basic (0.00s)
=== RUN   TestAccResourceServiceEdgeGroup_Basic
    resource_zpa_service_edge_group_test.go:24: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccResourceServiceEdgeGroup_Basic (0.00s)
=== CONT  TestAccDataSourceAccessPolicyClientTypes_Basic
=== CONT  TestAccDataSourceLSSClientTypes_Basic
=== NAME  TestAccDataSourceAccessPolicyClientTypes_Basic
    data_source_zpa_access_policy_client_types_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceAccessPolicyClientTypes_Basic (0.00s)
=== CONT  TestAccDataSourceLSSStatusCodes_Basic
=== CONT  TestAccDataSourceAccessPolicyPlatforms_Basic
=== NAME  TestAccDataSourceLSSClientTypes_Basic
    data_source_zpa_lss_config_client_types_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceLSSClientTypes_Basic (0.00s)
=== NAME  TestAccDataSourceLSSStatusCodes_Basic
    data_source_zpa_lss_config_status_codes_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceLSSStatusCodes_Basic (0.00s)
=== NAME  TestAccDataSourceAccessPolicyPlatforms_Basic
    data_source_zpa_access_policy_platform_test.go:10: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccDataSourceAccessPolicyPlatforms_Basic (0.00s)
PASS
ok  	github.com/zscaler/terraform-provider-zpa/v3/zpa	(cached)
?   	github.com/zscaler/terraform-provider-zpa/v3/zpa/common/testing/method	[no test files]
?   	github.com/zscaler/terraform-provider-zpa/v3/zpa/common/testing/variable	[no test files]
```

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
