### PR TITLE
fix: Prevent read panic and add new portal access rule capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 4.4.7 (July 15, 2026)
+
+### Notes
+
+- Release date: **(July 15, 2026)**
+- Supported Terraform version: **v1.x**
+
+### Enhancements
+
+- [PR #671](https://github.com/zscaler/terraform-provider-zpa/pull/671) Added new `privileged_portal_capabilities` options `UPLOAD_INSPECTED_SANDBOX`, and `UPLOAD_INSPECTED_SCAN` to resource `zpa_policy_portal_access_rule`
+
+### Bug Fixes
+
+- [PR #671](https://github.com/zscaler/terraform-provider-zpa/pull/671) - Fixed a provider panic ([Issue #670](https://github.com/zscaler/terraform-provider-zpa/issues/670)) caused by an unguarded error type assertion in the read functions of `zpa_application_segment`, `zpa_server_group`, `zpa_service_edge_group`, and `zpa_lss_config_controller`. Transient API errors (e.g. cancelled/timed-out requests) are now surfaced as recoverable Terraform errors instead of crashing the provider.
+
 ## 4.4.6 (June 30, 2026)
 
 ### Notes

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,9 +12,24 @@ Track all ZPA Terraform provider's releases. New resources, features, and bug fi
 
 ---
 
-``Last updated: v4.4.6``
+``Last updated: v4.4.7``
 
 ---
+
+## 4.4.7 (July 15, 2026)
+
+### Notes
+
+- Release date: **(July 15, 2026)**
+- Supported Terraform version: **v1.x**
+
+### Enhancements
+
+- [PR #671](https://github.com/zscaler/terraform-provider-zpa/pull/671) Added new `privileged_portal_capabilities` options `UPLOAD_INSPECTED_SANDBOX`, and `UPLOAD_INSPECTED_SCAN` to resource `zpa_policy_portal_access_rule`
+
+### Bug Fixes
+
+- [PR #671](https://github.com/zscaler/terraform-provider-zpa/pull/671) - Fixed a provider panic ([Issue #670](https://github.com/zscaler/terraform-provider-zpa/issues/670)) caused by an unguarded error type assertion in the read functions of `zpa_application_segment`, `zpa_server_group`, `zpa_service_edge_group`, and `zpa_lss_config_controller`. Transient API errors (e.g. cancelled/timed-out requests) are now surfaced as recoverable Terraform errors instead of crashing the provider.
 
 ## 4.4.6 (June 30, 2026)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ The ZPA Terraform Provider now offers support for [OneAPI](https://help.zscaler.
 
 **NOTE** As of version v4.0.0, this Terraform provider offers backwards compatibility to the Zscaler legacy API framework. This is the recommended authentication method for organizations whose tenants are still not migrated to [Zidentity](https://help.zscaler.com/zidentity/what-zidentity). 
 
-**NOTE** Notice that OneAPI and Zidentity is not currently supported for the following clouds: `GOV` and `GOVUS`. Refer to the [Legacy API Framework](#legacy-api-framework) for more information on how authenticate to these environments
+**NOTE**: Attention Government customers. OneAPI and Zidentity now support the government (FedRAMP) clouds via the unified `cloud=gov` and `cloud=govus` values. See the [OneAPI Government (FedRAMP) Cloud Environments](#oneapi-government-fedramp-cloud-environments) section below for details.
 
 ## Zenith Community - ZPA Terraform Provider Introduction
 
@@ -97,7 +97,11 @@ provider "zpa" {
 }
 ```
 
-**NOTE**: The `zscaler_cloud` is optional and only required when authenticating to other environments i.e `beta`
+**NOTE**: The `zscaler_cloud` is optional for production comercial Clouds and ONLY required when authenticating to other environments. Currently the only supported value are:
+
+- Production Commericial Clouds: The cloud parameter `IS NOT` required.
+- Test (Beta) Commercial Clouds: `beta`
+- FedRAMP Clouds: `gov` or `govus`
 
 ⚠️ **WARNING:** Hard-coding credentials into any Terraform configuration is not recommended, and risks secret leakage should this file be committed to public version control
 
@@ -110,6 +114,24 @@ As of version v4.0.0, this provider supports authentication via the new Zscaler 
 Zscaler OneAPI uses the OAuth 2.0 authorization framework to provide secure access to Zscaler Private Access (ZPA) APIs. OAuth 2.0 allows third-party applications to obtain controlled access to protected resources using access tokens. OneAPI uses the Client Credentials OAuth flow, in which client applications can exchange their credentials with the authorization server for an access token and obtain access to the API resources, without any user authentication involved in the process.
 
 * [ZPA API](https://help.zscaler.com/oneapi/understanding-oneapi#:~:text=Workload%20Groups-,ZPA%20API,-Zscaler%20Private%20Access)
+
+## OneAPI Government (FedRAMP) Cloud Environments
+
+OneAPI supports the Zscaler government (FedRAMP) clouds. These are FedRAMP-isolated environments served by a dedicated Zidentity identity provider and API gateway. To authenticate, set the `cloud` attribute (or `ZSCALER_CLOUD` environment variable) to one of the supported government values:
+
+| Argument        | Description                                                         | Environment Variable     |
+|-----------------|---------------------------------------------------------------------|--------------------------|
+| `vanity_domain` | _(String)_ Refers to the domain name used by your organization     | `ZSCALER_VANITY_DOMAIN`  |
+| `zscaler_cloud` | _(String)_ Supported Zidentity Gov Cloud `gov` or `govus`                | `ZSCALER_CLOUD`          |
+
+**NOTE** FedRAMP cloud is only supported when upgrading to the provider version `>=v4.4.6`. Earlier versions are NOT supported.
+
+For example, authenticating to the GOV environment:
+
+```sh
+export ZSCALER_VANITY_DOMAIN="acme"
+export ZSCALER_CLOUD="gov"
+```
 
 ### OneAPI (API Client Scope)
 

--- a/docs/resources/zpa_policy_portal_access_rule.md
+++ b/docs/resources/zpa_policy_portal_access_rule.md
@@ -107,6 +107,9 @@ resource "zpa_policy_portal_access_rule" "example" {
     - `access_uninspected_file` - (Boolean) Allows a User like an Admin to see all files marked Uninspected from other users in the tenant. Supported values: `true` or `false`
     - `request_approvals` - (Boolean) Indicates the request approvals is enabled or disabled. Supported values: `true` or `false`
     - `review_approvals` - (Boolean) Indicates the review approvals is enabled or disabled. Supported values: `true` or `false`
+    - `upload_inspected_sandbox` - (Boolean) Sandbox to inspect the file via ZIA sandbox and Scan to inspect the file via ZIA Deep Inspection
+    - `upload_inspected_scan` - (Boolean) Sandbox to inspect the file via ZIA sandbox and Scan to inspect the file via ZIA Deep Inspection
+    - `access_uninspected_file_sandbox` - (Boolean) Allows a User like an Admin to see all files marked Uninspected from other users in the tenant.
 
 ### Optional
 

--- a/zpa/resource_zpa_application_segment.go
+++ b/zpa/resource_zpa_application_segment.go
@@ -334,7 +334,7 @@ func resourceApplicationSegmentRead(ctx context.Context, d *schema.ResourceData,
 
 	resp, _, err := applicationsegment.Get(ctx, service, d.Id())
 	if err != nil {
-		if err.(*errorx.ErrorResponse).IsObjectNotFound() {
+		if respErr, ok := err.(*errorx.ErrorResponse); ok && respErr.IsObjectNotFound() {
 			log.Printf("[WARN] Removing application segment %s from state because it no longer exists in ZPA", d.Id())
 			d.SetId("")
 			return nil

--- a/zpa/resource_zpa_lss_config_controller.go
+++ b/zpa/resource_zpa_lss_config_controller.go
@@ -321,7 +321,7 @@ func resourceLSSConfigControllerRead(ctx context.Context, d *schema.ResourceData
 
 	resp, _, err := lssconfigcontroller.Get(ctx, service, d.Id())
 	if err != nil {
-		if err.(*errorx.ErrorResponse).IsObjectNotFound() {
+		if respErr, ok := err.(*errorx.ErrorResponse); ok && respErr.IsObjectNotFound() {
 			log.Printf("[WARN] Removing lss config controller %s from state because it no longer exists in ZPA", d.Id())
 			d.SetId("")
 			return nil

--- a/zpa/resource_zpa_policy_portal_access_rule.go
+++ b/zpa/resource_zpa_policy_portal_access_rule.go
@@ -119,7 +119,6 @@ func resourcePolicyPortalAccessRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"delete_file": {
@@ -128,6 +127,11 @@ func resourcePolicyPortalAccessRule() *schema.Resource {
 							Description: "Allows a User to delete files to reclaim space. Allowing deletion will prevent auditing of the file.",
 						},
 						"access_uninspected_file": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Allows a User like an Admin to see all files marked Uninspected from other users in the tenant.",
+						},
+						"access_uninspected_file_sandbox": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "Allows a User like an Admin to see all files marked Uninspected from other users in the tenant.",
@@ -141,6 +145,16 @@ func resourcePolicyPortalAccessRule() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: "Allows a User to review approvals",
+						},
+						"upload_inspected_sandbox": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Sandbox to inspect the file via ZIA sandbox and Scan to inspect the file via ZIA Deep Inspection",
+						},
+						"upload_inspected_scan": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Sandbox to inspect the file via ZIA sandbox and Scan to inspect the file via ZIA Deep Inspection",
 						},
 					},
 				},
@@ -316,15 +330,24 @@ func flattenPrivilegedPortalCapabilities(capabilities policysetcontrollerv2.Priv
 			capMap["request_approvals"] = true
 		case "REVIEW_APPROVALS":
 			capMap["review_approvals"] = true
+		case "UPLOAD_INSPECTED_SANDBOX":
+			capMap["upload_inspected_sandbox"] = true
+		case "UPLOAD_INSPECTED_SCAN":
+			capMap["upload_inspected_scan"] = true
+		case "ACCESS_UNINSPECTED_FILE_SANDBOX":
+			capMap["access_uninspected_file_sandbox"] = true
 		}
 	}
 
 	return []interface{}{
 		map[string]interface{}{
-			"delete_file":             capMap["delete_file"],
-			"access_uninspected_file": capMap["access_uninspected_file"],
-			"request_approvals":       capMap["request_approvals"],
-			"review_approvals":        capMap["review_approvals"],
+			"delete_file":                     capMap["delete_file"],
+			"access_uninspected_file":         capMap["access_uninspected_file"],
+			"access_uninspected_file_sandbox": capMap["access_uninspected_file_sandbox"],
+			"request_approvals":               capMap["request_approvals"],
+			"review_approvals":                capMap["review_approvals"],
+			"upload_inspected_sandbox":        capMap["upload_inspected_sandbox"],
+			"upload_inspected_scan":           capMap["upload_inspected_scan"],
 		},
 	}
 }
@@ -357,6 +380,15 @@ func expandPrivilegedPortalCapabilitiesRule(d *schema.ResourceData, policySetID 
 			}
 			if privCapsMap["review_approvals"].(bool) {
 				capabilities = append(capabilities, "REVIEW_APPROVALS")
+			}
+			if privCapsMap["upload_inspected_sandbox"].(bool) {
+				capabilities = append(capabilities, "UPLOAD_INSPECTED_SANDBOX")
+			}
+			if privCapsMap["upload_inspected_scan"].(bool) {
+				capabilities = append(capabilities, "UPLOAD_INSPECTED_SCAN")
+			}
+			if privCapsMap["access_uninspected_file_sandbox"].(bool) {
+				capabilities = append(capabilities, "ACCESS_UNINSPECTED_FILE_SANDBOX")
 			}
 		}
 	}

--- a/zpa/resource_zpa_server_group.go
+++ b/zpa/resource_zpa_server_group.go
@@ -234,7 +234,7 @@ func resourceServerGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	resp, _, err := servergroup.Get(ctx, service, d.Id())
 	if err != nil {
-		if err.(*errorx.ErrorResponse).IsObjectNotFound() {
+		if respErr, ok := err.(*errorx.ErrorResponse); ok && respErr.IsObjectNotFound() {
 			log.Printf("[WARN] Removing server group %s from state because it no longer exists in ZPA", d.Id())
 			d.SetId("")
 			return nil

--- a/zpa/resource_zpa_service_edge_group.go
+++ b/zpa/resource_zpa_service_edge_group.go
@@ -321,7 +321,7 @@ func resourceServiceEdgeGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	resp, _, err := serviceedgegroup.Get(ctx, service, d.Id())
 	if err != nil {
-		if err.(*errorx.ErrorResponse).IsObjectNotFound() {
+		if respErr, ok := err.(*errorx.ErrorResponse); ok && respErr.IsObjectNotFound() {
 			log.Printf("[WARN] Removing service edge group %s from state because it no longer exists in ZPA", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
- Fix provider panic (#670) from unguarded error type assertions in the read functions of zpa_application_segment, zpa_server_group, zpa_service_edge_group, and zpa_lss_config_controller; transient API errors are now returned as recoverable Terraform errors.
- Add privileged_portal_capabilities options UPLOAD_INSPECTED_SANDBOX and UPLOAD_INSPECTED_SCAN to zpa_policy_portal_access_rule (#671).

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
